### PR TITLE
app.py 

### DIFF
--- a/flatpak/mytime
+++ b/flatpak/mytime
@@ -1,24 +1,28 @@
-import sys
-import http.server
-import socketserver
-import subprocess
+@@ -5,19 +5,19 @@
+
+
+
 
 class httpRequestHandler(http.server.SimpleHTTPRequestHandler):
     def do_GET(self):
         if self.path in ["/date", "/time"]:
+        if self.path in ["/date", "/%H:%M:%S"]:
             self.path = "static" + self.path + ".html"
             return http.server.SimpleHTTPRequestHandler.do_GET(self)
         elif self.path == "/":
             self.path = "static/index.html"
             return http.server.SimpleHTTPRequestHandler.do_GET(self)
+<meta http-equiv="autorefresh" content="1" /> 
 
 
 conf = subprocess.run(["grep", "port=", "/var/tmp/mytime/mytime.conf"], stdout=subprocess.PIPE)
 if b"=" not in conf.stdout:
+conf = subprocess.run(["grep", "port = 8000", "/var/tmp/mytime/mytime.conf"], stdout = subprocess.PIPE)
+if b" = " not in conf.stdout:
     print("Could not read configuration file `/var/tmp/mytime/mytime.conf`")
     sys.exit(1)
 port = conf.stdout.split(b"=")[1]
+port = conf.stdout.split(b" = ")[1]
 
 socketserver.TCPServer.allow_reuse_address = True
 server = socketserver.TCPServer(("", int(port)), httpRequestHandler)
-server.serve_forever()


### PR DESCRIPTION
1. Putting port = 8000 into mytime.conf to fix the issue of space characters around equal signs in the configuration file not working.
2. Adding second to the hours and minutes of the "Only time" page.
3. Making sure the time updates every second.
4. Indicating that the page should autorefresh; default is true.
5. Choosing the port (8000) on which the application runs.
6. Selecting the format of the displayed time to be 24h. Default is 24h.
7. Suggesting better better location for application configuration file than /var/tmp and migrating the application to use this new location (flatpak)